### PR TITLE
Fix RTL display by adding 'dir' attribute

### DIFF
--- a/resources/views/code-field.blade.php
+++ b/resources/views/code-field.blade.php
@@ -11,6 +11,7 @@
     :required="$isRequired()"
     :state-path="$getStatePath()"
     :disabled="$isDisabled()"
+    dir="ltr"
 >
     <style>
         :root {


### PR DESCRIPTION
The current code editor component does not support right-to-left (RTL) display, causing the code to appear reversed when the interface is set to a right-to-left language such as Hebrew. This makes it challenging for RTL language users to read and edit code effectively.

Added the 'dir' attribute with the value 'ltr' to the relevant component to address the RTL display issue. 
This change ensures that the code appears correctly in right-to-left languages such as Hebrew.
