### PR TITLE
Allow phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5||^10.0",
+        "phpunit/phpunit": "^9.5||^10.0||^11.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {


### PR DESCRIPTION
I cannot install ur package unless i bump phpunit down to 10 in my project composer.json

But laravel 11 composer.json allow both phpunit 10 & 11