### PR TITLE
Added Length Constrained

### DIFF
--- a/src/CodeField.php
+++ b/src/CodeField.php
@@ -8,14 +8,17 @@ use Creagia\FilamentCodeField\Concerns\HasDisplayMode;
 use Creagia\FilamentCodeField\Concerns\LineNumbers;
 use Creagia\FilamentCodeField\Concerns\ProgrammingLanguages;
 use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Concerns;
+use Filament\Forms\Components\Contracts;
 
-class CodeField extends Field
+class CodeField extends Field implements Contracts\CanBeLengthConstrained
 {
     use Autocompletion;
     use ControlsHeight;
     use HasDisplayMode;
     use LineNumbers;
     use ProgrammingLanguages;
+    use Concerns\CanBeLengthConstrained;
 
     const PHP = 'php';
 


### PR DESCRIPTION
This update introduces a length constraint for Filament fields. This feature allows developers to set minimum and maximum character limits for text inputs directly within the Filament form configuration, adding greater flexibility and control and ensuring data consistency and validation at the form level.

**Usage:**
Developers can easily apply these constraints by using the **->minLength()** and **->maxLength()** methods within Filament field definitions.